### PR TITLE
[Fix] 편성 프리셋 확장 버그 수정, 가챠 쿨타임 출력 오류 수정

### DIFF
--- a/Assets/Workspace/LHW/LobbyScene3.unity
+++ b/Assets/Workspace/LHW/LobbyScene3.unity
@@ -4780,8 +4780,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1172440919}
   m_HandleRect: {fileID: 1172440918}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 0.99866307
+  m_Value: 1
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -10809,7 +10809,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.00031201952}
+  m_AnchoredPosition: {x: 0, y: -0.00013542175}
   m_SizeDelta: {x: 0, y: 300}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &916012041
@@ -22015,6 +22015,106 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 83269425}
     m_Modifications:
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.21186985
+      objectReference: {fileID: 0}
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -14.504898
+      objectReference: {fileID: 0}
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1.8999951
+      objectReference: {fileID: 0}
+    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.000015258789
+      objectReference: {fileID: 0}
+    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.17078255
+      objectReference: {fileID: 0}
+    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -19
+      objectReference: {fileID: 0}
+    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -4.013199
+      objectReference: {fileID: 0}
+    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -1.9979
+      objectReference: {fileID: 0}
+    - target: {fileID: 1884386296652048048, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2004097505528943821, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.16700001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -1.9979
+      objectReference: {fileID: 0}
+    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.20821747
+      objectReference: {fileID: 0}
+    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -13.504898
+      objectReference: {fileID: 0}
+    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.000015258789
+      objectReference: {fileID: 0}
     - target: {fileID: 4986206244445577502, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
       propertyPath: m_Pivot.x
@@ -22139,6 +22239,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: GachaUIPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 5743904577580251496, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5794698817558074444, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}

--- a/Assets/Workspace/LHW/LobbyScene3.unity
+++ b/Assets/Workspace/LHW/LobbyScene3.unity
@@ -8468,12 +8468,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 674902769}
   m_CullTransparentMesh: 1
---- !u!1 &685400570 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2004097505528943821, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-    type: 3}
-  m_PrefabInstance: {fileID: 1992830968}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &689301597
 GameObject:
   m_ObjectHideFlags: 0
@@ -8985,18 +8979,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 206.75232, y: 251.4514}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &722535015 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1585580720999431238, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-    type: 3}
-  m_PrefabInstance: {fileID: 1992830968}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &723318725 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4585042108140216145, guid: fcafc27e0bf614c4fa52902727dea5c2,
@@ -9733,18 +9715,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 796091014}
   m_CullTransparentMesh: 1
---- !u!114 &818301478 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3478527129764672670, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-    type: 3}
-  m_PrefabInstance: {fileID: 1992830968}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &821529231
 GameObject:
   m_ObjectHideFlags: 0
@@ -9970,12 +9940,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 830023651}
   m_CullTransparentMesh: 1
---- !u!1 &831165597 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1884386296652048048, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-    type: 3}
-  m_PrefabInstance: {fileID: 1992830968}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &834391624
 GameObject:
   m_ObjectHideFlags: 0
@@ -11878,22 +11842,22 @@ PrefabInstance:
     - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 518.69684
       objectReference: {fileID: 0}
     - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -202.6135
       objectReference: {fileID: 0}
     - target: {fileID: 6463488381361131179, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
@@ -11928,22 +11892,22 @@ PrefabInstance:
     - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 518.69684
       objectReference: {fileID: 0}
     - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -534.20447
       objectReference: {fileID: 0}
     - target: {fileID: 7629118952807006298, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
@@ -22015,106 +21979,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 83269425}
     m_Modifications:
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5000003
-      objectReference: {fileID: 0}
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.21186985
-      objectReference: {fileID: 0}
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -14.504898
-      objectReference: {fileID: 0}
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 1.8999951
-      objectReference: {fileID: 0}
-    - target: {fileID: 706718871037934223, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0.000015258789
-      objectReference: {fileID: 0}
-    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.17078255
-      objectReference: {fileID: 0}
-    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -19
-      objectReference: {fileID: 0}
-    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -4.013199
-      objectReference: {fileID: 0}
-    - target: {fileID: 900162525493916052, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -1.9979
-      objectReference: {fileID: 0}
-    - target: {fileID: 1884386296652048048, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2004097505528943821, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.16700001
-      objectReference: {fileID: 0}
-    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -20
-      objectReference: {fileID: 0}
-    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2430042519125248032, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -1.9979
-      objectReference: {fileID: 0}
-    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.20821747
-      objectReference: {fileID: 0}
-    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -13.504898
-      objectReference: {fileID: 0}
-    - target: {fileID: 3975920541268691925, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -0.000015258789
-      objectReference: {fileID: 0}
     - target: {fileID: 4986206244445577502, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
       propertyPath: m_Pivot.x
@@ -22215,35 +22079,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: _adCooltimeText
-      value: 
-      objectReference: {fileID: 722535015}
-    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: _adCooltimeImage
-      value: 
-      objectReference: {fileID: 831165597}
-    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: _dailyCooltimeText
-      value: 
-      objectReference: {fileID: 818301478}
-    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: _dailyCooltimeImage
-      value: 
-      objectReference: {fileID: 685400570}
     - target: {fileID: 5743904577580251496, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
       propertyPath: m_Name
       value: GachaUIPanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 5743904577580251496, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5794698817558074444, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
@@ -25525,22 +25364,22 @@ PrefabInstance:
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 521.15
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -202.6135
       objectReference: {fileID: 0}
     - target: {fileID: 5415918377121220459, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25557,22 +25396,22 @@ PrefabInstance:
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 521.15
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -534.20447
       objectReference: {fileID: 0}
     - target: {fileID: 6531942364391319876, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}

--- a/Assets/Workspace/LHW/LobbyScene3.unity
+++ b/Assets/Workspace/LHW/LobbyScene3.unity
@@ -153,7 +153,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -163,7 +163,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -213,12 +213,12 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 105.94865
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.50415
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2085,7 +2085,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2095,7 +2095,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2145,12 +2145,12 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 745.38715
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.50415
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2684,9 +2684,9 @@ RectTransform:
   - {fileID: 821529232}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 857.5494, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &221942597
@@ -2763,7 +2763,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2773,7 +2773,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -2823,12 +2823,12 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 958.5333
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.50415
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -4781,7 +4781,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1172440918}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.99866307
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -6212,7 +6212,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -6222,7 +6222,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -6272,12 +6272,12 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 539.9995
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -181.7763
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -6628,9 +6628,9 @@ RectTransform:
   - {fileID: 618235422}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 702.5404, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &531864136
@@ -8468,6 +8468,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 674902769}
   m_CullTransparentMesh: 1
+--- !u!1 &685400570 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2004097505528943821, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+    type: 3}
+  m_PrefabInstance: {fileID: 1992830968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &689301597
 GameObject:
   m_ObjectHideFlags: 0
@@ -8979,6 +8985,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 206.75232, y: 251.4514}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &722535015 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1585580720999431238, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+    type: 3}
+  m_PrefabInstance: {fileID: 1992830968}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &723318725 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4585042108140216145, guid: fcafc27e0bf614c4fa52902727dea5c2,
@@ -9133,7 +9151,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1080, y: 2340}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -9715,6 +9733,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 796091014}
   m_CullTransparentMesh: 1
+--- !u!114 &818301478 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3478527129764672670, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+    type: 3}
+  m_PrefabInstance: {fileID: 1992830968}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &821529231
 GameObject:
   m_ObjectHideFlags: 0
@@ -9940,6 +9970,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 830023651}
   m_CullTransparentMesh: 1
+--- !u!1 &831165597 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1884386296652048048, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+    type: 3}
+  m_PrefabInstance: {fileID: 1992830968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &834391624
 GameObject:
   m_ObjectHideFlags: 0
@@ -10525,7 +10561,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &891058753
 RectTransform:
   m_ObjectHideFlags: 0
@@ -10618,9 +10654,9 @@ RectTransform:
   - {fileID: 770363197}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 547.5314, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &900180155
@@ -10694,9 +10730,9 @@ RectTransform:
   - {fileID: 1037459749}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 392.52243, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &905401201
@@ -10773,7 +10809,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.00011045807}
+  m_AnchoredPosition: {x: 0, y: 0.00031201952}
   m_SizeDelta: {x: 0, y: 300}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &916012041
@@ -11500,7 +11536,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1010663259
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11839,6 +11875,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5492425109712257758, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6463488381361131179, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_Name
@@ -11865,6 +11921,26 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6621496109397430540, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704560591803077539, guid: eb86077d00fcbd14da06458f6bdbe047,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -11996,7 +12072,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -12006,7 +12082,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -12056,12 +12132,12 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 539.9995
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -494.92194
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -13552,7 +13628,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -13562,7 +13638,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -13612,12 +13688,12 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 532.24097
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.50415
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -15462,7 +15538,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1413247736
 RectTransform:
   m_ObjectHideFlags: 0
@@ -15708,7 +15784,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -15718,7 +15794,7 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -15768,12 +15844,12 @@ PrefabInstance:
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 319.09482
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.50415
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8749040064827735661, guid: db0f32b406e90ca4782d6f66056d2b61,
         type: 3}
@@ -18480,7 +18556,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000061035156, y: -1142.6}
+  m_AnchoredPosition: {x: 0, y: -1142.6}
   m_SizeDelta: {x: 0, y: 2285.2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1642654627
@@ -20389,9 +20465,9 @@ RectTransform:
   - {fileID: 830023652}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 237.51346, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1812885019
@@ -20468,7 +20544,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.00012207031}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: -0.00024414}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1826230555
@@ -20686,22 +20762,22 @@ PrefabInstance:
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 17.686138
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1242047316236396891, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
@@ -20716,42 +20792,42 @@ PrefabInstance:
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 208.43068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 113.05842
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8449476938524745396, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
@@ -20856,22 +20932,22 @@ PrefabInstance:
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.80295
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -21009,9 +21085,9 @@ RectTransform:
   - {fileID: 1509471936}
   m_Father: {fileID: 664574750}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 82.504486, y: -38.8805}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 151.9973, y: 137.5198}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1877784694
@@ -22022,7 +22098,7 @@ PrefabInstance:
     - target: {fileID: 4986206244445577502, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.00012207031
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4986206244445577502, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
@@ -22039,15 +22115,30 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: _adCooltimeText
+      value: 
+      objectReference: {fileID: 722535015}
+    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: _adCooltimeImage
+      value: 
+      objectReference: {fileID: 831165597}
+    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: _dailyCooltimeText
+      value: 
+      objectReference: {fileID: 818301478}
+    - target: {fileID: 5248923571039922520, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
+        type: 3}
+      propertyPath: _dailyCooltimeImage
+      value: 
+      objectReference: {fileID: 685400570}
     - target: {fileID: 5743904577580251496, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
       propertyPath: m_Name
       value: GachaUIPanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 5743904577580251496, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5794698817558074444, guid: 13d8e5efc6ae0fa4ab5a3fa83675c100,
         type: 3}
@@ -22423,7 +22514,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -22433,7 +22524,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -22483,12 +22574,12 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 539.9995
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -808.06757
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -23757,7 +23848,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -23767,7 +23858,7 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -23817,12 +23908,12 @@ PrefabInstance:
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 539.9995
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1121.2131
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3883355987914700000, guid: 8006f05f11756ae4a8d3e1f8f0e0079a,
         type: 3}
@@ -24116,22 +24207,22 @@ PrefabInstance:
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 17.686138
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 731991850253696704, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1242047316236396891, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
@@ -24146,42 +24237,42 @@ PrefabInstance:
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 208.43068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1802668259779649315, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 113.05842
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585759098515166978, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5569065967546910906, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
@@ -24333,22 +24424,22 @@ PrefabInstance:
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.80295
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8556641574439613469, guid: ee5498c5327fd9841943d67c78c6f7df,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -12.26325
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -24814,22 +24905,22 @@ PrefabInstance:
     - target: {fileID: 2537963622287267048, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2537963622287267048, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2537963622287267048, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 434.14117
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2537963622287267048, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2577435146842983051, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -24854,42 +24945,42 @@ PrefabInstance:
     - target: {fileID: 2595850814185492729, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2595850814185492729, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2595850814185492729, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 970.9762
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2595850814185492729, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2748997932933994654, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2748997932933994654, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2748997932933994654, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 792.0312
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2748997932933994654, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2824481039568082528, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -24954,22 +25045,22 @@ PrefabInstance:
     - target: {fileID: 2892326150027169527, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2892326150027169527, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2892326150027169527, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 613.0862
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2892326150027169527, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2966710383417869343, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -24994,17 +25085,17 @@ PrefabInstance:
     - target: {fileID: 3245650089295990759, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3245650089295990759, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3245650089295990759, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.40602243
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3271908078944953738, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25029,22 +25120,22 @@ PrefabInstance:
     - target: {fileID: 3356730695509033675, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3356730695509033675, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3356730695509033675, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 255.1962
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3356730695509033675, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3438989191291427910, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25109,42 +25200,42 @@ PrefabInstance:
     - target: {fileID: 3654534341646056135, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3654534341646056135, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3654534341646056135, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 434.14117
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3654534341646056135, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3857750239731777238, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3857750239731777238, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3857750239731777238, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 970.9762
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3857750239731777238, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3919715296464686991, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25209,22 +25300,22 @@ PrefabInstance:
     - target: {fileID: 4010821496474498737, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4010821496474498737, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4010821496474498737, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 792.0312
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4010821496474498737, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4081656029960038960, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25249,22 +25340,22 @@ PrefabInstance:
     - target: {fileID: 4155890789894709464, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4155890789894709464, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4155890789894709464, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 613.0862
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4155890789894709464, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4388490549333724069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25309,42 +25400,42 @@ PrefabInstance:
     - target: {fileID: 4547134931242577124, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4547134931242577124, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4547134931242577124, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 255.1962
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4547134931242577124, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 521.15
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5107308291622291290, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -202.6135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5415918377121220459, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25361,22 +25452,22 @@ PrefabInstance:
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 521.15
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6300507550605470069, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -534.20447
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6531942364391319876, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25456,22 +25547,22 @@ PrefabInstance:
     - target: {fileID: 7561619259287117371, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7561619259287117371, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7561619259287117371, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 76.2512
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7561619259287117371, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7838878564787106466, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
@@ -25598,22 +25689,22 @@ PrefabInstance:
     - target: {fileID: 8754838588115595284, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8754838588115595284, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8754838588115595284, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 76.2512
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8754838588115595284, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -114.465
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8996046963400639346, guid: fcafc27e0bf614c4fa52902727dea5c2,
         type: 3}

--- a/Assets/Workspace/LHW/LobbyScene3.unity.meta
+++ b/Assets/Workspace/LHW/LobbyScene3.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf840aff3b7b5324f920642aed04c5a1
+guid: 84c79217f07f8274e91d531fd4efe347
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Workspace/LHW/Prefabs/Gacha/GachaUIPanel.prefab
+++ b/Assets/Workspace/LHW/Prefabs/Gacha/GachaUIPanel.prefab
@@ -454,10 +454,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3907294349736126415}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.080000006, y: 0}
-  m_AnchorMax: {x: 0.2915651, y: 1}
-  m_AnchoredPosition: {x: 0.19999695, y: 0}
-  m_SizeDelta: {x: -14.504898, y: -18.504902}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.20821747, y: 1}
+  m_AnchoredPosition: {x: -0.000015258789, y: 0}
+  m_SizeDelta: {x: -13.504898, y: -18.504902}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &264835269137516255
 CanvasRenderer:
@@ -1009,7 +1009,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3471309911458732736
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1297,7 +1297,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3907294349736126415
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2568,10 +2568,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3471309911458732736}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.186, y: 0.067}
+  m_AnchorMin: {x: 0.17078255, y: 0.067}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1, y: -2}
-  m_SizeDelta: {x: -15, y: -6}
+  m_AnchoredPosition: {x: -4.013199, y: -1.9979}
+  m_SizeDelta: {x: -19, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &394472961012867967
 CanvasRenderer:
@@ -3460,10 +3460,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3907294349736126415}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.186, y: 0.067}
+  m_AnchorMin: {x: 0.16700001, y: 0.067}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1, y: -2}
-  m_SizeDelta: {x: -15, y: -6}
+  m_AnchoredPosition: {x: -5, y: -1.9979}
+  m_SizeDelta: {x: -20, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1586109616207497039
 CanvasRenderer:
@@ -3902,11 +3902,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3471309911458732736}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.080000006, y: 0}
-  m_AnchorMax: {x: 0.2915651, y: 1}
-  m_AnchoredPosition: {x: 0.19999695, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.21186985, y: 1}
+  m_AnchoredPosition: {x: 1.8999951, y: 0.000015258789}
   m_SizeDelta: {x: -14.504898, y: -18.504902}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5000003, y: 0.5}
 --- !u!222 &8888805775373334568
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Workspace/LHW/Scripts/Lobby/CharacterCompositionUI/TeamOrganizeManager.cs
+++ b/Assets/Workspace/LHW/Scripts/Lobby/CharacterCompositionUI/TeamOrganizeManager.cs
@@ -1,9 +1,11 @@
+using DG.Tweening;
 using Michsky.UI.ModernUIPack;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 [Serializable]
 public class TeamPresetData
@@ -286,6 +288,18 @@ public class TeamOrganizeManager : MonoBehaviour
         {
             _presetAddButton[i].buttonText = $"{(i + 3)}";
             _presetAddButton[i].UpdateUI();
+        }
+
+        for(int i = 0; i < _presetAddButton.Length; i++)
+        {
+            if(i <= TempDataManager.Instance.PresetData.Count- 2)
+            {
+                _presetAddButton[i].GetComponent<Button>().interactable = true;
+            }
+            else
+            {
+                _presetAddButton[i].GetComponent<Button>().interactable = false;
+            }
         }
     }
 

--- a/Assets/Workspace/LHW/Scripts/Lobby/PartySelectUI/PresetSelectUnit.cs
+++ b/Assets/Workspace/LHW/Scripts/Lobby/PartySelectUI/PresetSelectUnit.cs
@@ -53,6 +53,10 @@ public class PresetSelectUnit : MonoBehaviour
         if(TempDataManager.Instance.PresetData.Count < _index + 1)
         {
             SetactiveGameobject("LockedPartyButton");
+            if(TempDataManager.Instance.PresetData.Count < _index)
+            {
+                _lockedPartyButton.GetComponent<Button>().interactable = false;
+            }
             return;
         }
 
@@ -139,7 +143,7 @@ public class PresetSelectUnit : MonoBehaviour
         {
             if (PopupManager.Instance != null)
             {
-                PopupManager.instance.ShowConfirmationPopup("Add Preset?\nConsumes 500 Gold.", () => CreatePreset(), null);
+                PopupManager.instance.ShowConfirmationPopup("프리셋을 추가하시겠습니까?\n500 골드 소모", () => CreatePreset(), null);
             }
         }
     }

--- a/Assets/Workspace/LHW/Scripts/Lobby/RandomGacha/GachaUIController.cs
+++ b/Assets/Workspace/LHW/Scripts/Lobby/RandomGacha/GachaUIController.cs
@@ -59,7 +59,7 @@ public class GachaUIController : MonoBehaviour
 
     private void StopAdTimer()
     {
-        if(_adCooltimeTimer != null)
+        if (_adCooltimeTimer != null)
         {
             StopCoroutine(_adCooltimeTimer);
             _adCooltimeTimer = null;
@@ -72,7 +72,7 @@ public class GachaUIController : MonoBehaviour
 
     private void StartDailyTimer()
     {
-        if(_dailyCooltimeTimer != null)
+        if (_dailyCooltimeTimer != null)
         {
             StopCoroutine(_dailyCooltimeTimer);
         }
@@ -81,7 +81,7 @@ public class GachaUIController : MonoBehaviour
 
     private void StopDailyTimer()
     {
-        if(_dailyCooltimeTimer != null)
+        if (_dailyCooltimeTimer != null)
         {
             StopCoroutine(_dailyCooltimeTimer);
             _dailyCooltimeTimer = null;
@@ -100,7 +100,7 @@ public class GachaUIController : MonoBehaviour
 
     private void UpdateAdButton()
     {
-        switch(TimeManager.Instance.DailyAdGachaRewardInfo.state)
+        switch (TimeManager.Instance.DailyAdGachaRewardInfo.state)
         {
             case 2:
                 _adImages[0].color = Color.white;
@@ -108,7 +108,7 @@ public class GachaUIController : MonoBehaviour
                 _adCooltimeImage.gameObject.SetActive(false);
                 break;
 
-           case 1:
+            case 1:
                 _adImages[0].color = Color.grey;
                 _adImages[1].color = Color.white;
                 _adCooltimeImage.gameObject.SetActive(true);
@@ -117,6 +117,8 @@ public class GachaUIController : MonoBehaviour
                 _adImages[0].color = Color.grey;
                 _adImages[1].color = Color.grey;
                 _adCooltimeImage.gameObject.SetActive(true);
+                break;
+            default:
                 break;
         }
     }
@@ -145,21 +147,20 @@ public class GachaUIController : MonoBehaviour
     {
         while (true)
         {
-            if(TimeManager.Instance != null && _adCooltimeImage.activeSelf == true)
+            if (TimeManager.Instance != null && _adCooltimeImage.activeSelf == true)
             {
+                TimeManager.Instance.CanObtainAdGachaReward();
+
                 DateTime lastTime = TimeManager.Instance.DailyAdGachaRewardInfo.GetDateTime();
                 DateTime now = DateTime.Now;
 
-                TimeSpan cooltime = now - lastTime;
+                TimeSpan cooltime = lastTime.AddHours(12) - now;
 
-                // 다음 초기화 시간만 표기하도록
-                while(cooltime.TotalHours > 12)
-                {
-                    lastTime.AddHours(12);
-                }
-
-                _adCooltimeText.text = $"{cooltime.Hours}시간 {cooltime.Minutes}분";
+                _adCooltimeText.text = $"다음 초기화 : {cooltime.Hours}시간 {cooltime.Minutes}분";
             }
+
+            UpdateAdButton();
+
             yield return new WaitForSeconds(1);
         }
     }
@@ -170,13 +171,17 @@ public class GachaUIController : MonoBehaviour
         {
             if (TimeManager.Instance != null && _dailyCooltimeImage.activeSelf == true)
             {
+                TimeManager.Instance.CanObtainedFreeGachaReward();
+
                 DateTime nextdate = TimeManager.Instance.DailyFreeGachaRewardInfo.GetDateTime();
                 DateTime now = DateTime.Now;
 
                 TimeSpan cooltime = nextdate - now;
-                _dailyCooltimeText.text = $"{cooltime.Hours}시간 {cooltime.Minutes}분";
-                Debug.Log($"남은 시간 : {cooltime}");
+                _dailyCooltimeText.text = $"다음 초기화 : {cooltime.Hours}시간 {cooltime.Minutes}분";
             }
+
+            UpdateOneButton();
+
             yield return new WaitForSeconds(1);
         }
     }

--- a/Assets/Workspace/LHW/Scripts/Lobby/RandomGacha/RandomGachaSystem.cs
+++ b/Assets/Workspace/LHW/Scripts/Lobby/RandomGacha/RandomGachaSystem.cs
@@ -58,7 +58,7 @@ public class RandomGachaSystem : MonoBehaviour
 
         if(PopupManager.Instance != null)
         {
-            PopupManager.instance.ShowPopup("일일 무료 가챠를 전부 사용하였습니다.");
+            PopupManager.instance.ShowPopup("일일 광고 가챠를 전부 사용하였습니다.");
         }
     }
 
@@ -66,7 +66,13 @@ public class RandomGachaSystem : MonoBehaviour
     {
         if (DailyFreeGacha()) return;
 
-        ItemSelect(1);
+        // 재화 소모 일시로 막아둠(신원님 요청)
+        //ItemSelect(1);
+
+        if (PopupManager.Instance != null)
+        {
+            PopupManager.instance.ShowPopup("일일 무료 가챠를 이미 진행하였습니다.");
+        }
     }
 
     private bool DailyFreeGacha()
@@ -75,6 +81,7 @@ public class RandomGachaSystem : MonoBehaviour
         {
             TimeManager.Instance.SaveDailyFreeGachaResetTimeInfo();
             ItemSelect(1);
+            TimeManager.Instance.OnDailyGachaInfoChanged?.Invoke();
             return true;
         }
         return false;
@@ -86,6 +93,7 @@ public class RandomGachaSystem : MonoBehaviour
         {
             TimeManager.Instance.SaveAdGachaResetTimeInfo();
             ItemSelect(1);
+            TimeManager.Instance.OnDailyGachaInfoChanged?.Invoke();
             return true;
         }
 

--- a/Assets/Workspace/LHW/Scripts/Manager/TimeManager.cs
+++ b/Assets/Workspace/LHW/Scripts/Manager/TimeManager.cs
@@ -7,6 +7,11 @@ public class RewardInfo
     public long dateTicks; // DateTime을 Ticks로 저장
     public int state;      // 획득 여부 또는 스택 수
 
+    /// <summary>
+    /// 리워드 정보를 생성함.
+    /// </summary>
+    /// <param name="dateTicks">시간을 Long으로 변환</param>
+    /// <param name="state">획득여부 혹은 Stack수</param>
     public RewardInfo(long dateTicks, int state)
     {
         this.dateTicks = dateTicks;
@@ -44,7 +49,7 @@ public class TimeManager : MonoBehaviour
 
     [Header("Reference")]
     [SerializeField] private GoogleAdMob _adMob;
-    
+
     private RewardInfo _dailyFreeGachaRewardInfo;
     public RewardInfo DailyFreeGachaRewardInfo => _dailyFreeGachaRewardInfo;
 
@@ -60,6 +65,8 @@ public class TimeManager : MonoBehaviour
     }
 
     #region Data Load & Save
+
+    #region 일일 초기화
 
     private void LoadDailyFreeGachaResetTimeInfo()
     {
@@ -87,10 +94,14 @@ public class TimeManager : MonoBehaviour
         OnDailyGachaInfoChanged?.Invoke();
     }
 
+    #endregion
+
+    #region 12시간 초기화(가챠)
+
     private void LoadAdGachaResetTimeInfo()
     {
         // 테스트용 초기값: 11시간 전, 가챠 횟수 1회
-        _dailyAdGachaRewardInfo = new RewardInfo(DateTime.Now.AddHours(-11).AddMinutes(-3).Ticks, 1);
+        _dailyAdGachaRewardInfo = new RewardInfo(DateTime.Now.AddHours(-11).AddMinutes(-59).Ticks, 1);
 
         if (_dailyAdGachaRewardInfo.state < 2 && IsDailyAdGachaResetTime(out int stack))
         {
@@ -116,10 +127,27 @@ public class TimeManager : MonoBehaviour
 
     #endregion
 
+    #endregion
+
+    #region Obtain 판정
+
+    #region 일일 가챠 가능 여부 판정
+
     public bool CanObtainedFreeGachaReward()
     {
         if (_dailyFreeGachaRewardInfo.state == 1) return true;
         if (IsDailyFreeGachaResetTime(_dailyFreeGachaRewardInfo.GetDateTime())) return true;
+        return false;
+    }
+
+    private bool IsDailyFreeGachaResetTime(DateTime date)
+    {
+        DateTime now = DateTime.Now;
+
+        if (now.Year > date.Year && now.Hour >= date.Hour) return true;
+        if (now.Year == date.Year && now.Month > date.Month && now.Hour >= date.Hour) return true;        
+        if (now.Year == date.Year && now.Month == date.Month && now.Day > date.Day && now.Hour >= date.Hour) return true;
+        
         return false;
     }
 
@@ -133,20 +161,12 @@ public class TimeManager : MonoBehaviour
             if (_dailyAdGachaRewardInfo.state > 2) _dailyAdGachaRewardInfo.state = 2;
             return true;
         }
-
         return true;
     }
 
-    private bool IsDailyFreeGachaResetTime(DateTime date)
-    {
-        DateTime now = DateTime.Now;
+    #endregion
 
-        if (now.Year > date.Year && now.Hour >= date.Hour) return true;
-        if (now.Year == date.Year && now.Month > date.Month && now.Hour >= date.Hour) return true;
-        if (now.Year == date.Year && now.Month == date.Month && now.Day > date.Day && now.Hour >= date.Hour) return true;
-
-        return false;
-    }
+    #region 12시간 광고 가챠 가능 여부 판정
 
     /// <summary>
     /// 12시간 단위 누적 스택 계산
@@ -173,4 +193,8 @@ public class TimeManager : MonoBehaviour
 
         return false;
     }
+
+    #endregion
+
+    #endregion
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업 내용
- 편성 프리셋 확장 버그 수정
<img width="1178" height="1269" alt="편성 버그" src="https://github.com/user-attachments/assets/0e6e09ba-0883-4ab9-b4d8-979411cc41cb" />

- 가챠 쿨타임 잘못 출력됨 & 업데이트 안됨 버그 수정

## 🎥 스크린샷 / 영상 (선택)

https://github.com/user-attachments/assets/aafb520c-d8c0-4ae4-b300-8ebf01d11ec6

UI 정상 업데이트되는 사항 확인함

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)
- 데이터 연동 없이 로컬로만 돌아가고 있음